### PR TITLE
support for additional libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Deploy a non-HA Flink cluster with three taskmanagers:
 
     $ helm install --name my-cluster --set flink.num_taskmanagers=3 flink*.tgz
 
+Install additional (optional) libraries from the flink distribution (you can only reference libraries from `$FLINK_BASEDIR/opt` here):
+
+	$ helm install --name my-cluster --set flink.additional_libs="{flink-metrics-prometheus-1.4.0.jar,flink-metrics-dropwizard-1.4.0.jar}" flink*.tgz
+
 Deploy an HA Flink cluster with three taskmanagers:
 
     $ cat > values.yaml <<EOF

--- a/helm/flink/templates/deployment-jobmanager.yaml
+++ b/helm/flink/templates/deployment-jobmanager.yaml
@@ -10,6 +10,16 @@ spec:
         app: {{ template "fullname" . }}
         component: jobmanager
     spec:
+      initContainers:
+      - name: flink-copy-libs
+        image: {{ .Values.image }}:{{ .Values.imageTag }}
+        command:
+        - sh
+        - -c
+        - cp /opt/flink/lib/* {{ range .Values.flink.additional_libs}}/opt/flink/opt/{{ . }} {{ end }} /flink-lib;
+        volumeMounts:
+        - name: flink-lib
+          mountPath: /flink-lib
       containers:
       - name: jobmanager
         image: {{ .Values.image }}:{{ .Values.imageTag }}
@@ -38,6 +48,8 @@ spec:
           mountPath: /etc/flink
         - name: {{ template "fullname" . }}-hadoop-config
           mountPath: /etc/hadoop/conf
+        - name: flink-lib
+          mountPath: /opt/flink/lib
       volumes:
         - name: {{ template "fullname" . }}-flink-config
           configMap:
@@ -45,3 +57,5 @@ spec:
         - name: {{ template "fullname" . }}-hadoop-config
           configMap:
             name: {{ template "fullname" . }}-hadoop-config
+        - name: flink-lib
+          emptyDir: {}

--- a/helm/flink/templates/deployment-taskmanager.yaml
+++ b/helm/flink/templates/deployment-taskmanager.yaml
@@ -10,6 +10,16 @@ spec:
         app: {{ template "fullname" . }}
         component: taskmanager
     spec:
+      initContainers:
+      - name: flink-copy-libs
+        image: {{ .Values.image }}:{{ .Values.imageTag }}
+        command:
+        - sh
+        - -c
+        - cp /opt/flink/lib/* {{ range .Values.flink.additional_libs}}/opt/flink/opt/{{ . }} {{ end }} /flink-lib;
+        volumeMounts:
+        - name: flink-lib
+          mountPath: /flink-lib
       containers:
       - name: taskmanager
         image: {{ .Values.image }}:{{ .Values.imageTag }}
@@ -38,6 +48,8 @@ spec:
           mountPath: /etc/flink
         - name: {{ template "fullname" . }}-hadoop-config
           mountPath: /etc/hadoop/conf
+        - name: flink-lib
+          mountPath: /opt/flink/lib
       volumes:
         - name: {{ template "fullname" . }}-flink-config
           configMap:
@@ -45,3 +57,5 @@ spec:
         - name: {{ template "fullname" . }}-hadoop-config
           configMap:
             name: {{ template "fullname" . }}-hadoop-config
+        - name: flink-lib
+          emptyDir: {}


### PR DESCRIPTION
this adds a config flag (`flink.additional_libs`) that allows users to reference and include addtional libraries from the flink distribution. this is useful e.g. if you want to enable metrics but don't want to create a custom image for that. Basically what happens is that an init container (that runs the same image as jobmanager and taskmanager) mounts an `emptyDir`, copies the relevant libs from `$FLINK_BASEDIR/lib` and `$FLINK_BASEDIR/opt` (<-- those are the ones that you can reference via `--set flink.additional_libs`) to that `emptyDir` and mounts that directory in the jobmanager and taskmanager containers to `/opt/flink/lib`.