### PR TITLE
Adding livenessProb to the jobmanager to improve reliability

### DIFF
--- a/helm/flink/templates/deployment-jobmanager.yaml
+++ b/helm/flink/templates/deployment-jobmanager.yaml
@@ -26,6 +26,12 @@ spec:
         env:
         - name: FLINK_CONF_DIR
           value: /etc/flink
+        livenessProbe:
+          httpGet:
+            path: /overview
+            port: 8081
+          initialDelaySeconds: 30
+          periodSeconds: 10
         resources:
           limits:
             cpu: {{ .Values.resources.jobmanager.limits.cpu }}


### PR DESCRIPTION
With a livenessProb, Kubernetes can restart the job manager. I find this quite useful when enabling HA mode. 
For instance I observed that if the zookeeper quorum is not fully ready (but endpoint is responding), the Job manager may hang forever waiting for leader election. With the livenessProb, Kubernetes will detect the issue (if job manager has no leader, it returns an error) and restart the container